### PR TITLE
Add optional SNP genotypes, hormonal status, and editable health profile

### DIFF
--- a/app/src/main/java/com/uc/caffeine/data/DerivedOnboardingProfile.kt
+++ b/app/src/main/java/com/uc/caffeine/data/DerivedOnboardingProfile.kt
@@ -6,3 +6,19 @@ data class DerivedOnboardingProfile(
     val sleepTimeHour: Int,
     val sleepTimeMinute: Int,
 )
+
+/**
+ * Raw onboarding answers stored as primitives for DataStore persistence.
+ * Kept separate from the onboarding UI enums to avoid data→ui package dependency.
+ */
+data class ProfileFactors(
+    val ageBucket: String? = null,
+    val weightValue: Int = 60,
+    val weightUnit: String = "Kilograms",
+    val hasInsomnia: Boolean? = null,
+    val smokingHabit: String? = null,
+    val heavyAlcohol: Boolean? = null,
+    val heavyCaffeine: Boolean? = null,
+    val liverDisease: String? = null,
+    val medications: Set<String> = emptySet(),
+)

--- a/app/src/main/java/com/uc/caffeine/data/SettingsRepository.kt
+++ b/app/src/main/java/com/uc/caffeine/data/SettingsRepository.kt
@@ -9,6 +9,7 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -18,7 +19,7 @@ import java.util.Locale
 // Extension property to create DataStore
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "user_settings")
 
-internal object SettingsKeys {
+object SettingsKeys {
     val HALF_LIFE_MINUTES = intPreferencesKey("half_life_minutes")
     val SLEEP_THRESHOLD_MG = intPreferencesKey("sleep_threshold_mg")
     val ABSORPTION_RATE_MINUTES = intPreferencesKey("absorption_rate_minutes")
@@ -30,6 +31,20 @@ internal object SettingsKeys {
     val DATE_FORMAT = stringPreferencesKey("date_format")
     val TIME_ZONE_ID = stringPreferencesKey("time_zone_id")
     val ONBOARDING_COMPLETE = booleanPreferencesKey("onboarding_complete")
+    val CYP1A2_GENOTYPE = stringPreferencesKey("cyp1a2_genotype")
+    val AHR_GENOTYPE = stringPreferencesKey("ahr_genotype")
+    val HORMONAL_STATUS = stringPreferencesKey("hormonal_status")
+
+    // Raw onboarding profile factors
+    val PROFILE_AGE_BUCKET = stringPreferencesKey("profile_age_bucket")
+    val PROFILE_WEIGHT_VALUE = intPreferencesKey("profile_weight_value")
+    val PROFILE_WEIGHT_UNIT = stringPreferencesKey("profile_weight_unit")
+    val PROFILE_HAS_INSOMNIA = stringPreferencesKey("profile_has_insomnia")
+    val PROFILE_SMOKING_HABIT = stringPreferencesKey("profile_smoking_habit")
+    val PROFILE_HEAVY_ALCOHOL = stringPreferencesKey("profile_heavy_alcohol")
+    val PROFILE_HEAVY_CAFFEINE = stringPreferencesKey("profile_heavy_caffeine")
+    val PROFILE_LIVER_DISEASE = stringPreferencesKey("profile_liver_disease")
+    val PROFILE_MEDICATIONS = stringSetPreferencesKey("profile_medications")
 }
 
 /**
@@ -128,9 +143,37 @@ class SettingsRepository(private val context: Context) {
         }
     }
 
-    suspend fun completeOnboarding(profile: DerivedOnboardingProfile) {
+    suspend fun updateCyp1a2Genotype(genotype: Cyp1a2Genotype) {
+        context.dataStore.edit { prefs ->
+            prefs[SettingsKeys.CYP1A2_GENOTYPE] = genotype.name
+        }
+    }
+
+    suspend fun updateAhrGenotype(genotype: AhrGenotype) {
+        context.dataStore.edit { prefs ->
+            prefs[SettingsKeys.AHR_GENOTYPE] = genotype.name
+        }
+    }
+
+    suspend fun updateHormonalStatus(status: HormonalStatus) {
+        context.dataStore.edit { prefs ->
+            prefs[SettingsKeys.HORMONAL_STATUS] = status.name
+        }
+    }
+
+    suspend fun updateProfileFactor(block: MutablePreferences.() -> Unit) {
+        context.dataStore.edit { prefs ->
+            prefs.block()
+        }
+    }
+
+    suspend fun completeOnboarding(
+        profile: DerivedOnboardingProfile,
+        factors: ProfileFactors? = null,
+    ) {
         context.dataStore.edit { prefs ->
             prefs.writeOnboardingCompletion(profile)
+            factors?.let { prefs.writeProfileFactors(it) }
         }
     }
 
@@ -156,7 +199,44 @@ internal fun Preferences.toUserSettings(defaultSettings: UserSettings): UserSett
         dateFormat = AppDateFormat.fromStorage(this[SettingsKeys.DATE_FORMAT]),
         timeZoneId = this[SettingsKeys.TIME_ZONE_ID] ?: defaultSettings.timeZoneId,
         isOnboardingComplete = this[SettingsKeys.ONBOARDING_COMPLETE] ?: hasLegacyProfilePrefs,
+        profileFactors = this.toProfileFactors(),
+        cyp1a2Genotype = Cyp1a2Genotype.fromStorage(this[SettingsKeys.CYP1A2_GENOTYPE]),
+        ahrGenotype = AhrGenotype.fromStorage(this[SettingsKeys.AHR_GENOTYPE]),
+        hormonalStatus = HormonalStatus.fromStorage(this[SettingsKeys.HORMONAL_STATUS]),
     )
+}
+
+fun Preferences.toProfileFactors(): ProfileFactors {
+    return ProfileFactors(
+        ageBucket = this[SettingsKeys.PROFILE_AGE_BUCKET],
+        weightValue = this[SettingsKeys.PROFILE_WEIGHT_VALUE] ?: 60,
+        weightUnit = this[SettingsKeys.PROFILE_WEIGHT_UNIT] ?: "Kilograms",
+        hasInsomnia = this[SettingsKeys.PROFILE_HAS_INSOMNIA]?.toBooleanStrictOrNull(),
+        smokingHabit = this[SettingsKeys.PROFILE_SMOKING_HABIT],
+        heavyAlcohol = this[SettingsKeys.PROFILE_HEAVY_ALCOHOL]?.toBooleanStrictOrNull(),
+        heavyCaffeine = this[SettingsKeys.PROFILE_HEAVY_CAFFEINE]?.toBooleanStrictOrNull(),
+        liverDisease = this[SettingsKeys.PROFILE_LIVER_DISEASE],
+        medications = this[SettingsKeys.PROFILE_MEDICATIONS] ?: emptySet(),
+    )
+}
+
+internal fun MutablePreferences.writeProfileFactors(factors: ProfileFactors) {
+    factors.ageBucket?.let { this[SettingsKeys.PROFILE_AGE_BUCKET] = it }
+    this[SettingsKeys.PROFILE_WEIGHT_VALUE] = factors.weightValue
+    this[SettingsKeys.PROFILE_WEIGHT_UNIT] = factors.weightUnit
+    factors.hasInsomnia?.let { this[SettingsKeys.PROFILE_HAS_INSOMNIA] = it.toString() }
+    factors.smokingHabit?.let { this[SettingsKeys.PROFILE_SMOKING_HABIT] = it }
+    factors.heavyAlcohol?.let { this[SettingsKeys.PROFILE_HEAVY_ALCOHOL] = it.toString() }
+    factors.heavyCaffeine?.let { this[SettingsKeys.PROFILE_HEAVY_CAFFEINE] = it.toString() }
+    factors.liverDisease?.let { this[SettingsKeys.PROFILE_LIVER_DISEASE] = it }
+    if (factors.medications.isNotEmpty()) {
+        this[SettingsKeys.PROFILE_MEDICATIONS] = factors.medications
+    }
+
+    // When OC is in the medication set, also set hormonal status
+    if (factors.medications.contains("OralContraceptives")) {
+        this[SettingsKeys.HORMONAL_STATUS] = HormonalStatus.ORAL_CONTRACEPTIVES.name
+    }
 }
 
 internal fun MutablePreferences.writeOnboardingCompletion(profile: DerivedOnboardingProfile) {

--- a/app/src/main/java/com/uc/caffeine/data/UserSettings.kt
+++ b/app/src/main/java/com/uc/caffeine/data/UserSettings.kt
@@ -1,10 +1,62 @@
 package com.uc.caffeine.data
 
 import java.time.ZoneId
+import kotlin.math.roundToInt
+
+/**
+ * CYP1A2 rs762551 genotype — affects caffeine metabolism speed.
+ * A/A is the "fast metabolizer" reference genotype.
+ */
+enum class Cyp1a2Genotype(val label: String, val clearanceFactor: Double) {
+    NOT_SET("Not set", 1.0),
+    AA("A/A — fast metabolizer", 1.0),
+    AC("A/C — intermediate", 0.78),
+    CC("C/C — slow metabolizer", 0.63),
+    ;
+
+    companion object {
+        fun fromStorage(value: String?): Cyp1a2Genotype =
+            entries.find { it.name == value } ?: NOT_SET
+    }
+}
+
+/**
+ * AHR rs2066853 genotype — affects CYP1A2 expression level.
+ * G/G is the normal-expression reference genotype.
+ */
+enum class AhrGenotype(val label: String, val clearanceFactor: Double) {
+    NOT_SET("Not set", 1.0),
+    GG("G/G — normal", 1.0),
+    A_CARRIER("G/A or A/A — reduced", 0.78),
+    ;
+
+    companion object {
+        fun fromStorage(value: String?): AhrGenotype =
+            entries.find { it.name == value } ?: NOT_SET
+    }
+}
+
+/**
+ * Hormonal status that modulates caffeine clearance.
+ * Pregnancy progressively suppresses CYP1A2; oral contraceptives inhibit it.
+ */
+enum class HormonalStatus(val label: String, val clearanceFactor: Double) {
+    NONE("None", 1.0),
+    ORAL_CONTRACEPTIVES("Hormonal contraceptives", 0.48),
+    PREGNANT_FIRST("Pregnant — 1st trimester", 0.73),
+    PREGNANT_SECOND("Pregnant — 2nd trimester", 0.48),
+    PREGNANT_THIRD("Pregnant — 3rd trimester", 0.28),
+    ;
+
+    companion object {
+        fun fromStorage(value: String?): HormonalStatus =
+            entries.find { it.name == value } ?: NONE
+    }
+}
 
 /**
  * User preferences for personalized caffeine tracking.
- * 
+ *
  * These settings affect half-life calculations and sleep recommendations.
  */
 data class UserSettings(
@@ -74,4 +126,40 @@ data class UserSettings(
      * Whether the first-run onboarding flow has been completed or intentionally skipped.
      */
     val isOnboardingComplete: Boolean = false,
-)
+
+    /**
+     * Raw onboarding profile factors, stored for later editing from Settings.
+     */
+    val profileFactors: ProfileFactors = ProfileFactors(),
+
+    /**
+     * Optional CYP1A2 rs762551 genotype for more accurate metabolism modeling.
+     */
+    val cyp1a2Genotype: Cyp1a2Genotype = Cyp1a2Genotype.NOT_SET,
+
+    /**
+     * Optional AHR rs2066853 genotype for more accurate metabolism modeling.
+     */
+    val ahrGenotype: AhrGenotype = AhrGenotype.NOT_SET,
+
+    /**
+     * Optional hormonal status (pregnancy or oral contraceptives).
+     */
+    val hormonalStatus: HormonalStatus = HormonalStatus.NONE,
+) {
+    /**
+     * Combined clearance factor from optional genetic and hormonal modifiers.
+     * Values < 1.0 mean slower clearance (longer half-life).
+     */
+    val clearanceFactor: Double
+        get() = cyp1a2Genotype.clearanceFactor *
+                ahrGenotype.clearanceFactor *
+                hormonalStatus.clearanceFactor
+
+    /**
+     * Effective half-life after applying genetic and hormonal modifiers.
+     * Use this for all PK calculations instead of [halfLifeMinutes] directly.
+     */
+    val effectiveHalfLifeMinutes: Int
+        get() = (halfLifeMinutes / clearanceFactor).roundToInt()
+}

--- a/app/src/main/java/com/uc/caffeine/ui/onboarding/OnboardingComponents.kt
+++ b/app/src/main/java/com/uc/caffeine/ui/onboarding/OnboardingComponents.kt
@@ -76,6 +76,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -111,7 +112,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -1305,8 +1308,10 @@ internal fun WeightStepperCard(
     onWeightUnitSelected: (WeightUnit) -> Unit,
     onIncrement: () -> Unit,
     onDecrement: () -> Unit,
+    onWeightChanged: (Int) -> Unit = {},
 ) {
     val haptics = rememberAppHaptics()
+    var showInputDialog by rememberSaveable { mutableStateOf(false) }
 
     Surface(
         shape = RoundedCornerShape(24.dp),
@@ -1353,13 +1358,24 @@ internal fun WeightStepperCard(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.spacedBy(2.dp),
                 ) {
+                    Surface(
+                        onClick = {
+                            haptics.toggle()
+                            showInputDialog = true
+                        },
+                        shape = RoundedCornerShape(12.dp),
+                        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+                    ) {
+                        Text(
+                            text = weightValue.toString(),
+                            style = MaterialTheme.typography.headlineLarge,
+                            color = MaterialTheme.colorScheme.primary,
+                            maxLines = 1,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+                        )
+                    }
                     Text(
-                        text = weightValue.toString(),
-                        style = MaterialTheme.typography.headlineLarge,
-                        maxLines = 1,
-                    )
-                    Text(
-                        text = "Default starting weight in ${weightUnit.label}",
+                        text = "Tap number to type, or use +/\u2212",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         textAlign = TextAlign.Center,
@@ -1382,6 +1398,65 @@ internal fun WeightStepperCard(
             }
         }
     }
+
+    if (showInputDialog) {
+        WeightInputDialog(
+            currentValue = weightValue,
+            weightUnit = weightUnit,
+            onConfirm = { newValue ->
+                onWeightChanged(newValue)
+                showInputDialog = false
+            },
+            onDismiss = { showInputDialog = false },
+        )
+    }
+}
+
+@Composable
+private fun WeightInputDialog(
+    currentValue: Int,
+    weightUnit: WeightUnit,
+    onConfirm: (Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var text by rememberSaveable { mutableStateOf(currentValue.toString()) }
+    val parsed = text.toIntOrNull()
+    val isValid = parsed != null && parsed in weightUnit.minSelectable()..weightUnit.maxSelectable()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(
+                onClick = { parsed?.let { onConfirm(weightUnit.clamp(it)) } },
+                enabled = isValid,
+            ) {
+                Text("OK")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+        title = { Text("Enter weight") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(
+                    value = text,
+                    onValueChange = { text = it.filter { c -> c.isDigit() } },
+                    label = { Text("Weight (${weightUnit.label})") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    singleLine = true,
+                    isError = text.isNotEmpty() && !isValid,
+                )
+                Text(
+                    text = "Range: ${weightUnit.minSelectable()}–${weightUnit.maxSelectable()} ${weightUnit.label}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/uc/caffeine/ui/onboarding/OnboardingModels.kt
+++ b/app/src/main/java/com/uc/caffeine/ui/onboarding/OnboardingModels.kt
@@ -74,7 +74,7 @@ enum class Medication(
 ) {
     None("None", 0),
     Cimetidine("Cimetidine", 45),
-    OralContraceptives("Oral contraceptives", 60),
+    OralContraceptives("Hormonal contraceptives", 0),
     Ciprofloxacin("Ciprofloxacin", 120),
     Fluvoxamine("Fluvoxamine", 180),
     OtherCyp1A2Inhibitor("Other CYP1A2 inhibitor", 60),
@@ -190,7 +190,7 @@ internal fun LiverDisease.buttonLabel(): String {
 
 internal fun Medication.buttonLabel(): String {
     return when (this) {
-        Medication.OralContraceptives -> "Oral contraceptives"
+        Medication.OralContraceptives -> "Hormonal contraceptives"
         Medication.OtherCyp1A2Inhibitor -> "Other CYP1A2 inhibitor"
         else -> label
     }

--- a/app/src/main/java/com/uc/caffeine/ui/onboarding/OnboardingRoot.kt
+++ b/app/src/main/java/com/uc/caffeine/ui/onboarding/OnboardingRoot.kt
@@ -102,6 +102,7 @@ fun OnboardingRoot(
                             onWeightIncrement = viewModel::incrementWeight,
                             onWeightDecrement = viewModel::decrementWeight,
                             onWeightUnitSelected = viewModel::updateWeightUnit,
+                            onWeightChanged = viewModel::setWeight,
                         )
 
                         OnboardingDestination.Sleep -> SleepScreen(

--- a/app/src/main/java/com/uc/caffeine/ui/onboarding/OnboardingScreens.kt
+++ b/app/src/main/java/com/uc/caffeine/ui/onboarding/OnboardingScreens.kt
@@ -97,6 +97,7 @@ internal fun BasicInfoScreen(
     onWeightIncrement: () -> Unit,
     onWeightDecrement: () -> Unit,
     onWeightUnitSelected: (WeightUnit) -> Unit,
+    onWeightChanged: (Int) -> Unit = {},
 ) {
     OnboardingScaffold(
         title = "Set your baseline",
@@ -136,6 +137,7 @@ internal fun BasicInfoScreen(
                 onWeightUnitSelected = onWeightUnitSelected,
                 onIncrement = onWeightIncrement,
                 onDecrement = onWeightDecrement,
+                onWeightChanged = onWeightChanged,
             )
         }
     }

--- a/app/src/main/java/com/uc/caffeine/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/com/uc/caffeine/ui/onboarding/OnboardingViewModel.kt
@@ -3,6 +3,7 @@ package com.uc.caffeine.ui.onboarding
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.uc.caffeine.data.ProfileFactors
 import com.uc.caffeine.data.SettingsRepository
 import java.time.LocalTime
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -51,6 +52,10 @@ class OnboardingViewModel(application: Application) : AndroidViewModel(applicati
 
     fun decrementWeight() {
         updateAnswers { answers -> answers.adjustedWeight(delta = -1) }
+    }
+
+    fun setWeight(value: Int) {
+        updateAnswers { answers -> answers.copy(weightValue = answers.weightUnit.clamp(value)) }
     }
 
     fun updateWeightUnit(weightUnit: WeightUnit) {
@@ -121,10 +126,14 @@ class OnboardingViewModel(application: Application) : AndroidViewModel(applicati
         val profile = state.currentProfile() ?: return
         if (!state.legalAcknowledged || state.isSaving) return
 
+        val factors = if (!state.useDefaultProfile) {
+            state.answers.toProfileFactors()
+        } else null
+
         viewModelScope.launch {
             _uiState.update { currentState -> currentState.copy(isSaving = true) }
             runCatching {
-                settingsRepository.completeOnboarding(profile)
+                settingsRepository.completeOnboarding(profile, factors)
             }.onSuccess {
                 _uiState.update { currentState ->
                     currentState.copy(
@@ -154,3 +163,15 @@ class OnboardingViewModel(application: Application) : AndroidViewModel(applicati
         }
     }
 }
+
+private fun OnboardingAnswers.toProfileFactors(): ProfileFactors = ProfileFactors(
+    ageBucket = ageBucket?.name,
+    weightValue = weightValue,
+    weightUnit = weightUnit.name,
+    hasInsomnia = hasInsomnia,
+    smokingHabit = smokingHabit?.name,
+    heavyAlcohol = heavyAlcohol,
+    heavyCaffeine = heavyCaffeine,
+    liverDisease = liverDisease?.name,
+    medications = medications.map { it.name }.toSet(),
+)

--- a/app/src/main/java/com/uc/caffeine/ui/screens/settings/CaffeineProfile.kt
+++ b/app/src/main/java/com/uc/caffeine/ui/screens/settings/CaffeineProfile.kt
@@ -1,5 +1,10 @@
 package com.uc.caffeine.ui.screens.settings
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -15,6 +20,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Science
 import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -23,32 +29,62 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.uc.caffeine.data.AhrGenotype
+import com.uc.caffeine.data.Cyp1a2Genotype
+import com.uc.caffeine.data.HormonalStatus
 import com.uc.caffeine.data.UserSettings
 import com.uc.caffeine.ui.components.SettingsPageScaffold
 import com.uc.caffeine.ui.components.rememberAppHaptics
+import com.uc.caffeine.ui.onboarding.AgeBucket
+import com.uc.caffeine.ui.onboarding.LiverDisease
+import com.uc.caffeine.ui.onboarding.Medication
+import com.uc.caffeine.ui.onboarding.SmokingHabit
 import com.uc.caffeine.ui.onboarding.SleepTimePickerCard
+import com.uc.caffeine.ui.onboarding.WeightStepperCard
+import com.uc.caffeine.ui.onboarding.WeightUnit
+import com.uc.caffeine.ui.onboarding.buttonLabel
+import com.uc.caffeine.ui.viewmodel.CaffeineViewModel
 import com.uc.caffeine.util.formatTimeOfDay
 import java.time.LocalTime
 
 @Composable
 internal fun CaffeineProfileSettingsScreen(
     userSettings: UserSettings,
+    viewModel: CaffeineViewModel,
     onBack: () -> Unit,
-    onHalfLifeChange: (Int) -> Unit,
-    onTimeChange: (Int, Int) -> Unit,
-    onThresholdChange: (Int) -> Unit,
     onRedoOnboarding: () -> Unit,
 ) {
     val halfLifeHours = userSettings.halfLifeMinutes / 60
+    val effectiveHalfLifeHours = userSettings.effectiveHalfLifeMinutes / 60
+    val hasModifiers = userSettings.clearanceFactor != 1.0
     val bedtime = formatTimeOfDay(
         hour = userSettings.sleepTimeHour,
         minute = userSettings.sleepTimeMinute,
         settings = userSettings,
     )
+    val factors = userSettings.profileFactors
+    val currentAgeBucket = factors.ageBucket?.let {
+        runCatching { AgeBucket.valueOf(it) }.getOrNull()
+    }
+    val currentWeightUnit = runCatching { WeightUnit.valueOf(factors.weightUnit) }
+        .getOrDefault(WeightUnit.Kilograms)
+    val currentSmokingHabit = factors.smokingHabit?.let {
+        runCatching { SmokingHabit.valueOf(it) }.getOrNull()
+    }
+    val currentLiverDisease = factors.liverDisease?.let {
+        runCatching { LiverDisease.valueOf(it) }.getOrNull()
+    }
+    val currentMedications = factors.medications.mapNotNull {
+        runCatching { Medication.valueOf(it) }.getOrNull()
+    }.toSet()
 
     SettingsPageScaffold(
         title = "Caffeine Profile",
@@ -102,8 +138,8 @@ internal fun CaffeineProfileSettingsScreen(
                 ) {
                     ProfileSnapshotMetric(
                         title = "Estimated half-life",
-                        value = "$halfLifeHours hr",
-                        description = "How long caffeine tends to linger in your system.",
+                        value = if (hasModifiers) "$effectiveHalfLifeHours hr (base $halfLifeHours hr)" else "$halfLifeHours hr",
+                        description = if (hasModifiers) "Adjusted for your genetic and hormonal modifiers." else "How long caffeine tends to linger in your system.",
                     )
                     HorizontalDivider()
                     ProfileSnapshotMetric(
@@ -126,10 +162,10 @@ internal fun CaffeineProfileSettingsScreen(
                 supportingText = "Average is around 5 hours, but you can make it more personal here.",
                 hint = "Adjust in 1-hour steps",
                 onDecrease = {
-                    onHalfLifeChange((halfLifeHours - 1).coerceIn(2, 12))
+                    viewModel.updateHalfLife((halfLifeHours - 1).coerceIn(2, 12))
                 },
                 onIncrease = {
-                    onHalfLifeChange((halfLifeHours + 1).coerceIn(2, 12))
+                    viewModel.updateHalfLife((halfLifeHours + 1).coerceIn(2, 12))
                 },
                 decreaseEnabled = halfLifeHours > 2,
                 increaseEnabled = halfLifeHours < 12,
@@ -142,7 +178,7 @@ internal fun CaffeineProfileSettingsScreen(
                     userSettings.sleepTimeMinute,
                 ),
                 onSleepTimeChanged = { time ->
-                    onTimeChange(time.hour, time.minute)
+                    viewModel.updateSleepTime(time.hour, time.minute)
                 },
             )
 
@@ -152,13 +188,98 @@ internal fun CaffeineProfileSettingsScreen(
                 supportingText = "Keep this lower if caffeine affects your sleep easily, higher if your usual cutoff is more forgiving.",
                 hint = "Adjust in 5 mg steps",
                 onDecrease = {
-                    onThresholdChange((userSettings.sleepThresholdMg - 5).coerceIn(20, 200))
+                    viewModel.updateSleepThreshold((userSettings.sleepThresholdMg - 5).coerceIn(20, 200))
                 },
                 onIncrease = {
-                    onThresholdChange((userSettings.sleepThresholdMg + 5).coerceIn(20, 200))
+                    viewModel.updateSleepThreshold((userSettings.sleepThresholdMg + 5).coerceIn(20, 200))
                 },
                 decreaseEnabled = userSettings.sleepThresholdMg > 20,
                 increaseEnabled = userSettings.sleepThresholdMg < 200,
+            )
+
+            // ── Health Profile Factors ───────────────────────────────────
+            SettingsSectionHeader(title = "Health Profile")
+
+            Text(
+                text = "These factors shape your estimated half-life and sleep threshold. Changing them will recompute your profile.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            GenotypeSelectorCard(
+                title = "Age range",
+                description = "Caffeine may linger longer for older adults.",
+                options = AgeBucket.entries,
+                selected = currentAgeBucket,
+                labelFor = { it.label },
+                onSelected = { viewModel.updateProfileAgeBucket(it) },
+            )
+
+            WeightStepperCard(
+                weightValue = factors.weightValue,
+                weightUnit = currentWeightUnit,
+                onWeightUnitSelected = { viewModel.updateProfileWeightUnit(it) },
+                onIncrement = { viewModel.updateProfileWeight(factors.weightValue + 1) },
+                onDecrement = { viewModel.updateProfileWeight(factors.weightValue - 1) },
+                onWeightChanged = { viewModel.updateProfileWeight(it) },
+            )
+
+            GenotypeSelectorCard(
+                title = "Sleep sensitivity",
+                description = "If insomnia is part of the picture, the threshold stays more conservative.",
+                options = listOf(true, false),
+                selected = factors.hasInsomnia,
+                labelFor = { if (it) "Yes" else "No" },
+                onSelected = { viewModel.updateProfileInsomnia(it) },
+            )
+
+            GenotypeSelectorCard(
+                title = "Smoking habit",
+                description = "Smoking can speed up caffeine clearance by inducing CYP1A2.",
+                options = SmokingHabit.entries,
+                selected = currentSmokingHabit,
+                labelFor = { it.buttonLabel() },
+                onSelected = { viewModel.updateProfileSmokingHabit(it) },
+            )
+
+            GenotypeSelectorCard(
+                title = "Heavy alcohol use",
+                description = "Heavy alcohol use can slow clearance and lower your effective threshold.",
+                options = listOf(true, false),
+                selected = factors.heavyAlcohol,
+                labelFor = { if (it) "Yes" else "No" },
+                onSelected = { viewModel.updateProfileHeavyAlcohol(it) },
+            )
+
+            GenotypeSelectorCard(
+                title = "High daily caffeine",
+                description = "Frequent high intake may increase tolerance.",
+                options = listOf(true, false),
+                selected = factors.heavyCaffeine,
+                labelFor = { if (it) "Yes" else "No" },
+                onSelected = { viewModel.updateProfileHeavyCaffeine(it) },
+            )
+
+            GenotypeSelectorCard(
+                title = "Liver context",
+                description = "Liver disease can substantially slow caffeine clearance.",
+                options = LiverDisease.entries,
+                selected = currentLiverDisease,
+                labelFor = { it.buttonLabel() },
+                onSelected = { viewModel.updateProfileLiverDisease(it) },
+            )
+
+            MedicationMultiSelectCard(
+                currentMedications = currentMedications,
+                onMedicationToggled = { viewModel.toggleProfileMedication(it) },
+            )
+
+            // ── Advanced Metabolism ──────────────────────────────────────
+            AdvancedMetabolismCard(
+                userSettings = userSettings,
+                onCyp1a2Change = viewModel::updateCyp1a2Genotype,
+                onAhrChange = viewModel::updateAhrGenotype,
+                onHormonalStatusChange = viewModel::updateHormonalStatus,
             )
 
             Surface(
@@ -313,6 +434,259 @@ private fun ExpressiveStepperCard(
                     Icon(
                         imageVector = Icons.Filled.Add,
                         contentDescription = "Increase $title",
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AdvancedMetabolismCard(
+    userSettings: UserSettings,
+    onCyp1a2Change: (Cyp1a2Genotype) -> Unit,
+    onAhrChange: (AhrGenotype) -> Unit,
+    onHormonalStatusChange: (HormonalStatus) -> Unit,
+) {
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    val haptics = rememberAppHaptics()
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(24.dp),
+        color = MaterialTheme.colorScheme.surfaceContainerHighest,
+        border = BorderStroke(
+            width = 1.dp,
+            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.4f),
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Science,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.size(20.dp),
+                        )
+                        Text(
+                            text = "Advanced Metabolism",
+                            style = MaterialTheme.typography.titleMedium,
+                        )
+                    }
+                    Text(
+                        text = "Optional genetic and hormonal factors that fine-tune your half-life estimate.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+
+            OutlinedButton(
+                onClick = {
+                    haptics.toggle()
+                    expanded = !expanded
+                },
+            ) {
+                Text(if (expanded) "Hide options" else "Show options")
+            }
+
+            AnimatedVisibility(
+                visible = expanded,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut(),
+            ) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    Text(
+                        text = "If you know your CYP1A2 or AHR genotype (e.g. from 23andMe or similar), you can enter it here. These are entirely optional.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+
+                    GenotypeSelectorCard(
+                        title = "CYP1A2 rs762551",
+                        description = "Controls caffeine metabolism speed. A/A is the fast-metabolizer reference.",
+                        options = Cyp1a2Genotype.entries,
+                        selected = userSettings.cyp1a2Genotype,
+                        labelFor = { it.label },
+                        onSelected = onCyp1a2Change,
+                    )
+
+                    GenotypeSelectorCard(
+                        title = "AHR rs2066853",
+                        description = "Affects CYP1A2 expression level. G/G is normal.",
+                        options = AhrGenotype.entries,
+                        selected = userSettings.ahrGenotype,
+                        labelFor = { it.label },
+                        onSelected = onAhrChange,
+                    )
+
+                    GenotypeSelectorCard(
+                        title = "Hormonal status",
+                        description = "Pregnancy and oral contraceptives can substantially slow caffeine clearance.",
+                        options = HormonalStatus.entries,
+                        selected = userSettings.hormonalStatus,
+                        labelFor = { it.label },
+                        onSelected = onHormonalStatusChange,
+                    )
+
+                    if (userSettings.clearanceFactor != 1.0) {
+                        Surface(
+                            shape = RoundedCornerShape(16.dp),
+                            color = MaterialTheme.colorScheme.tertiaryContainer,
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(14.dp),
+                                verticalArrangement = Arrangement.spacedBy(4.dp),
+                            ) {
+                                Text(
+                                    text = "Effective half-life: ${userSettings.effectiveHalfLifeMinutes / 60} hr ${userSettings.effectiveHalfLifeMinutes % 60} min",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    color = MaterialTheme.colorScheme.onTertiaryContainer,
+                                )
+                                Text(
+                                    text = "Base ${userSettings.halfLifeMinutes / 60} hr adjusted by a combined clearance factor of ${"%.2f".format(userSettings.clearanceFactor)}.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.8f),
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SettingsSectionHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(top = 8.dp),
+    )
+}
+
+@Composable
+private fun <T> GenotypeSelectorCard(
+    title: String,
+    description: String,
+    options: List<T>,
+    selected: T?,
+    labelFor: (T) -> String,
+    onSelected: (T) -> Unit,
+) {
+    val haptics = rememberAppHaptics()
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            options.forEach { option ->
+                val isSelected = option == selected
+                Surface(
+                    onClick = {
+                        haptics.toggle()
+                        onSelected(option)
+                    },
+                    shape = RoundedCornerShape(12.dp),
+                    color = if (isSelected)
+                        MaterialTheme.colorScheme.primaryContainer
+                    else
+                        MaterialTheme.colorScheme.surfaceContainerHigh,
+                    border = if (isSelected)
+                        BorderStroke(1.5.dp, MaterialTheme.colorScheme.primary)
+                    else
+                        BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)),
+                ) {
+                    Text(
+                        text = labelFor(option),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 14.dp, vertical = 12.dp),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (isSelected)
+                            MaterialTheme.colorScheme.onPrimaryContainer
+                        else
+                            MaterialTheme.colorScheme.onSurface,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MedicationMultiSelectCard(
+    currentMedications: Set<Medication>,
+    onMedicationToggled: (Medication) -> Unit,
+) {
+    val haptics = rememberAppHaptics()
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text = "Medications that may slow caffeine clearance",
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = "Pick any that apply. If none do, select None.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Medication.entries.forEach { medication ->
+                val isSelected = currentMedications.contains(medication)
+                Surface(
+                    onClick = {
+                        haptics.toggle()
+                        onMedicationToggled(medication)
+                    },
+                    shape = RoundedCornerShape(12.dp),
+                    color = if (isSelected)
+                        MaterialTheme.colorScheme.primaryContainer
+                    else
+                        MaterialTheme.colorScheme.surfaceContainerHigh,
+                    border = if (isSelected)
+                        BorderStroke(1.5.dp, MaterialTheme.colorScheme.primary)
+                    else
+                        BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)),
+                ) {
+                    Text(
+                        text = medication.buttonLabel(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 14.dp, vertical = 12.dp),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (isSelected)
+                            MaterialTheme.colorScheme.onPrimaryContainer
+                        else
+                            MaterialTheme.colorScheme.onSurface,
                     )
                 }
             }

--- a/app/src/main/java/com/uc/caffeine/ui/screens/settings/SettingsRoot.kt
+++ b/app/src/main/java/com/uc/caffeine/ui/screens/settings/SettingsRoot.kt
@@ -78,10 +78,8 @@ fun SettingsScreen(
 
                     SettingsDestination.CaffeineProfile -> CaffeineProfileSettingsScreen(
                         userSettings = userSettings,
+                        viewModel = viewModel,
                         onBack = { nestedBackStack.removeLastOrNull() },
-                        onHalfLifeChange = viewModel::updateHalfLife,
-                        onTimeChange = viewModel::updateSleepTime,
-                        onThresholdChange = viewModel::updateSleepThreshold,
                         onRedoOnboarding = onRedoOnboarding,
                     )
 

--- a/app/src/main/java/com/uc/caffeine/ui/viewmodel/CaffeineViewModel.kt
+++ b/app/src/main/java/com/uc/caffeine/ui/viewmodel/CaffeineViewModel.kt
@@ -3,11 +3,25 @@ package com.uc.caffeine.ui.viewmodel
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.datastore.preferences.core.MutablePreferences
+import com.uc.caffeine.data.AhrGenotype
 import com.uc.caffeine.data.AppDateFormat
 import com.uc.caffeine.data.CaffeineDatabase
+import com.uc.caffeine.data.Cyp1a2Genotype
+import com.uc.caffeine.data.HormonalStatus
+import com.uc.caffeine.data.ProfileFactors
+import com.uc.caffeine.data.SettingsKeys
 import com.uc.caffeine.data.SettingsRepository
+import com.uc.caffeine.data.toProfileFactors
 import com.uc.caffeine.data.ThemeMode
 import com.uc.caffeine.data.UserSettings
+import com.uc.caffeine.ui.onboarding.AgeBucket
+import com.uc.caffeine.ui.onboarding.LiverDisease
+import com.uc.caffeine.ui.onboarding.Medication
+import com.uc.caffeine.ui.onboarding.OnboardingAnswers
+import com.uc.caffeine.ui.onboarding.OnboardingProfileCalculator
+import com.uc.caffeine.ui.onboarding.SmokingHabit
+import com.uc.caffeine.ui.onboarding.WeightUnit
 import com.uc.caffeine.data.model.ConsumptionEntry
 import com.uc.caffeine.data.model.DEFAULT_CONSUMPTION_DURATION_MINUTES
 import com.uc.caffeine.data.model.DrinkPreset
@@ -33,6 +47,7 @@ import com.patrykandpatrick.vico.compose.cartesian.data.lineSeries
 import com.patrykandpatrick.vico.compose.pie.data.PieChartModelProducer
 import com.patrykandpatrick.vico.compose.pie.data.pieSeries
 import java.time.LocalDate
+import java.time.LocalTime
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -241,7 +256,7 @@ class CaffeineViewModel(application: Application) : AndroidViewModel(application
         CaffeineCalculator.calculateCurrentLevel(
             entries = allEntries,
             currentTimeMillis = currentTime,
-            halfLifeMinutes = settings.halfLifeMinutes
+            halfLifeMinutes = settings.effectiveHalfLifeMinutes
         )
     }.flowOn(Dispatchers.Default)
     .stateIn(
@@ -264,7 +279,7 @@ class CaffeineViewModel(application: Application) : AndroidViewModel(application
         val caffeineLevel = CaffeineCalculator.calculateCurrentLevel(
             entries = allEntries,
             currentTimeMillis = bedtime,  // Calculate AT bedtime, not now
-            halfLifeMinutes = settings.halfLifeMinutes
+            halfLifeMinutes = settings.effectiveHalfLifeMinutes
         )
         
         Pair(caffeineLevel, bedtime)
@@ -288,7 +303,7 @@ class CaffeineViewModel(application: Application) : AndroidViewModel(application
             .map { entry ->
                 CaffeineCalculator.calculatePeakTime(
                     entry = entry,
-                    halfLifeMinutes = settings.halfLifeMinutes,
+                    halfLifeMinutes = settings.effectiveHalfLifeMinutes,
                 )
             }
             .filter { candidatePeakTime -> candidatePeakTime > now }
@@ -602,10 +617,178 @@ class CaffeineViewModel(application: Application) : AndroidViewModel(application
         }
     }
 
+    fun updateCyp1a2Genotype(genotype: Cyp1a2Genotype) {
+        viewModelScope.launch {
+            settingsRepo.updateCyp1a2Genotype(genotype)
+        }
+    }
+
+    fun updateAhrGenotype(genotype: AhrGenotype) {
+        viewModelScope.launch {
+            settingsRepo.updateAhrGenotype(genotype)
+        }
+    }
+
+    fun updateHormonalStatus(status: HormonalStatus) {
+        viewModelScope.launch {
+            settingsRepo.updateProfileFactor {
+                this[SettingsKeys.HORMONAL_STATUS] = status.name
+                // Sync: if setting OC, add to medications; if clearing OC, remove from medications
+                val currentMeds = (this[SettingsKeys.PROFILE_MEDICATIONS] ?: emptySet()).toMutableSet()
+                if (status == HormonalStatus.ORAL_CONTRACEPTIVES) {
+                    currentMeds.remove(Medication.None.name)
+                    currentMeds.add(Medication.OralContraceptives.name)
+                } else {
+                    currentMeds.remove(Medication.OralContraceptives.name)
+                }
+                if (currentMeds.isNotEmpty()) {
+                    this[SettingsKeys.PROFILE_MEDICATIONS] = currentMeds
+                }
+            }
+        }
+    }
+
     fun updateTimeZoneId(timeZoneId: String) {
         viewModelScope.launch {
             settingsRepo.updateTimeZoneId(timeZoneId)
         }
+    }
+
+    // Profile factor update functions — each saves the raw value and recomputes the derived profile.
+    fun updateProfileAgeBucket(ageBucket: AgeBucket?) {
+        updateProfileFactorAndRecompute {
+            if (ageBucket != null) {
+                this[SettingsKeys.PROFILE_AGE_BUCKET] = ageBucket.name
+            }
+        }
+    }
+
+    fun updateProfileWeight(value: Int) {
+        updateProfileFactorAndRecompute {
+            this[SettingsKeys.PROFILE_WEIGHT_VALUE] = value
+        }
+    }
+
+    fun updateProfileWeightUnit(unit: WeightUnit) {
+        val current = userSettings.value.profileFactors
+        val convertedWeight = unit.convertFrom(current.weightValue, runCatching {
+            WeightUnit.valueOf(current.weightUnit)
+        }.getOrDefault(WeightUnit.Kilograms))
+        updateProfileFactorAndRecompute {
+            this[SettingsKeys.PROFILE_WEIGHT_UNIT] = unit.name
+            this[SettingsKeys.PROFILE_WEIGHT_VALUE] = convertedWeight
+        }
+    }
+
+    fun updateProfileInsomnia(hasInsomnia: Boolean) {
+        updateProfileFactorAndRecompute {
+            this[SettingsKeys.PROFILE_HAS_INSOMNIA] = hasInsomnia.toString()
+        }
+    }
+
+    fun updateProfileSmokingHabit(smokingHabit: SmokingHabit) {
+        updateProfileFactorAndRecompute {
+            this[SettingsKeys.PROFILE_SMOKING_HABIT] = smokingHabit.name
+        }
+    }
+
+    fun updateProfileHeavyAlcohol(heavyAlcohol: Boolean) {
+        updateProfileFactorAndRecompute {
+            this[SettingsKeys.PROFILE_HEAVY_ALCOHOL] = heavyAlcohol.toString()
+        }
+    }
+
+    fun updateProfileHeavyCaffeine(heavyCaffeine: Boolean) {
+        updateProfileFactorAndRecompute {
+            this[SettingsKeys.PROFILE_HEAVY_CAFFEINE] = heavyCaffeine.toString()
+        }
+    }
+
+    fun updateProfileLiverDisease(liverDisease: LiverDisease) {
+        updateProfileFactorAndRecompute {
+            this[SettingsKeys.PROFILE_LIVER_DISEASE] = liverDisease.name
+        }
+    }
+
+    fun toggleProfileMedication(medication: Medication) {
+        val current = userSettings.value.profileFactors.medications.mapNotNull {
+            runCatching { Medication.valueOf(it) }.getOrNull()
+        }.toMutableSet()
+
+        when (medication) {
+            Medication.None -> {
+                if (current == setOf(Medication.None)) current.clear()
+                else { current.clear(); current.add(Medication.None) }
+            }
+            else -> {
+                current.remove(Medication.None)
+                if (current.contains(medication)) current.remove(medication)
+                else current.add(medication)
+            }
+        }
+
+        val medicationNames = current.map { it.name }.toSet()
+        updateProfileFactorAndRecompute {
+            this[SettingsKeys.PROFILE_MEDICATIONS] = medicationNames
+            // Sync OC medication ↔ hormonal status
+            if (medicationNames.contains("OralContraceptives")) {
+                this[SettingsKeys.HORMONAL_STATUS] = HormonalStatus.ORAL_CONTRACEPTIVES.name
+            } else if (this[SettingsKeys.HORMONAL_STATUS] == HormonalStatus.ORAL_CONTRACEPTIVES.name) {
+                this[SettingsKeys.HORMONAL_STATUS] = HormonalStatus.NONE.name
+            }
+        }
+    }
+
+    private fun updateProfileFactorAndRecompute(
+        block: MutablePreferences.() -> Unit,
+    ) {
+        viewModelScope.launch {
+            settingsRepo.updateProfileFactor {
+                block()
+                // Recompute profile from all stored factors
+                val factors = toProfileFactors()
+                val answers = buildOnboardingAnswers(factors, userSettings.value)
+                if (answers?.isProfileReady() == true) {
+                    val profile = OnboardingProfileCalculator.calculateProfile(answers)
+                    this[SettingsKeys.HALF_LIFE_MINUTES] = profile.halfLifeMinutes
+                    this[SettingsKeys.SLEEP_THRESHOLD_MG] = profile.sleepThresholdMg
+                }
+            }
+        }
+    }
+
+    private fun buildOnboardingAnswers(
+        factors: ProfileFactors,
+        settings: UserSettings,
+    ): OnboardingAnswers? {
+        val ageBucket = factors.ageBucket?.let {
+            runCatching { AgeBucket.valueOf(it) }.getOrNull()
+        } ?: return null
+        val weightUnit = runCatching { WeightUnit.valueOf(factors.weightUnit) }
+            .getOrDefault(WeightUnit.Kilograms)
+        val smokingHabit = factors.smokingHabit?.let {
+            runCatching { SmokingHabit.valueOf(it) }.getOrNull()
+        } ?: return null
+        val liverDisease = factors.liverDisease?.let {
+            runCatching { LiverDisease.valueOf(it) }.getOrNull()
+        } ?: return null
+        val medications = factors.medications.mapNotNull {
+            runCatching { Medication.valueOf(it) }.getOrNull()
+        }.toSet()
+        if (medications.isEmpty()) return null
+
+        return OnboardingAnswers(
+            ageBucket = ageBucket,
+            weightValue = factors.weightValue,
+            weightUnit = weightUnit,
+            sleepTime = LocalTime.of(settings.sleepTimeHour, settings.sleepTimeMinute),
+            hasInsomnia = factors.hasInsomnia ?: return null,
+            smokingHabit = smokingHabit,
+            heavyAlcohol = factors.heavyAlcohol ?: return null,
+            heavyCaffeine = factors.heavyCaffeine ?: return null,
+            liverDisease = liverDisease,
+            medications = medications,
+        )
     }
 
     suspend fun getUnitsForDrink(drinkId: Int): List<DrinkUnit> {

--- a/app/src/main/java/com/uc/caffeine/util/AnalyticsUtils.kt
+++ b/app/src/main/java/com/uc/caffeine/util/AnalyticsUtils.kt
@@ -265,7 +265,7 @@ private fun buildDailyBedtimeStat(
     val caffeineMg = CaffeineCalculator.calculateCurrentLevel(
         entries = entries,
         currentTimeMillis = bedtimeMillis,
-        halfLifeMinutes = settings.halfLifeMinutes,
+        halfLifeMinutes = settings.effectiveHalfLifeMinutes,
     )
 
     return DailyBedtimeStat(

--- a/app/src/main/java/com/uc/caffeine/util/ChartDataGenerator.kt
+++ b/app/src/main/java/com/uc/caffeine/util/ChartDataGenerator.kt
@@ -49,7 +49,7 @@ object ChartDataGenerator {
             entries = entries,
             targetLevelMg = BASELINE_TARGET_MG,
             currentTimeMillis = currentTime,
-            halfLifeMinutes = settings.halfLifeMinutes,
+            halfLifeMinutes = settings.effectiveHalfLifeMinutes,
         )?.coerceAtMost(currentTime + MAX_FUTURE_BASELINE_WINDOW_MILLIS)
         val baselineTailEndTime = baselineReturnTime?.plus(BASE_INTERVAL_MILLIS) ?: currentTime
         val endTime = roundUpToInterval(
@@ -79,7 +79,7 @@ object ChartDataGenerator {
             entries = entries,
             startTime = domainStartTime,
             endTime = endTime,
-            halfLifeMinutes = settings.halfLifeMinutes,
+            halfLifeMinutes = settings.effectiveHalfLifeMinutes,
         )
 
         return ChartData(
@@ -105,7 +105,7 @@ object ChartDataGenerator {
         val intervalMillis = BASE_INTERVAL_MILLIS
         val peakTime = CaffeineCalculator.calculatePeakTime(
             entry = entry,
-            halfLifeMinutes = settings.halfLifeMinutes,
+            halfLifeMinutes = settings.effectiveHalfLifeMinutes,
         )
         val startTime = roundDownToInterval(entry.startedAtMillis, intervalMillis)
         val maxWindowEnd = startTime + (MAX_DETAIL_WINDOW_HOURS * 60 * 60 * 1000L)
@@ -124,7 +124,7 @@ object ChartDataGenerator {
                         caffeineContributionMg = CaffeineCalculator.calculateEntryContribution(
                             entry = entry,
                             currentTimeMillis = pointTime,
-                            halfLifeMinutes = settings.halfLifeMinutes,
+                            halfLifeMinutes = settings.effectiveHalfLifeMinutes,
                         )
                     )
                 )
@@ -135,12 +135,12 @@ object ChartDataGenerator {
         val peakContribution = CaffeineCalculator.calculateEntryContribution(
             entry = entry,
             currentTimeMillis = peakTime,
-            halfLifeMinutes = settings.halfLifeMinutes,
+            halfLifeMinutes = settings.effectiveHalfLifeMinutes,
         )
         val currentContribution = CaffeineCalculator.calculateEntryContribution(
             entry = entry,
             currentTimeMillis = currentTime,
-            halfLifeMinutes = settings.halfLifeMinutes,
+            halfLifeMinutes = settings.effectiveHalfLifeMinutes,
         )
         val peakMarkerIndex = dataPoints.indices.minByOrNull { index ->
             abs(dataPoints[index].timestampMillis - peakTime)
@@ -214,7 +214,7 @@ object ChartDataGenerator {
             val actualCaffeineLevel = CaffeineCalculator.calculateCurrentLevel(
                 entries = entries,
                 currentTimeMillis = pointTime,
-                halfLifeMinutes = settings.halfLifeMinutes,
+                halfLifeMinutes = settings.effectiveHalfLifeMinutes,
             )
             val displayCaffeineLevel = when {
                 entries.isEmpty() -> actualCaffeineLevel


### PR DESCRIPTION
Allow users to optionally provide CYP1A2 and AHR genotype data and hormonal status (pregnancy trimester / hormonal contraceptives) to refine caffeine half-life estimates using a multiplicative PK model.

All onboarding health factors (age, weight, smoking, medications, etc.) are now persisted and editable directly from Settings > Caffeine Profile without re-running onboarding. Changing any factor recomputes the derived half-life and sleep threshold.

Other improvements:
- Weight input supports direct text entry in addition to +/- stepper
- Hormonal contraceptives synced bidirectionally between medications and hormonal status selections to prevent double-counting