### PR TITLE
feature(hydration): log hydration data to HealthConnect

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.health.WRITE_NUTRITION"/>
     <uses-permission android:name="android.permission.health.READ_NUTRITION"/>
     <uses-permission android:name="android.permission.health.READ_SLEEP"/>
+    <uses-permission android:name="android.permission.health.WRITE_HYDRATION"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 

--- a/app/src/main/java/com/uc/caffeine/data/HealthConnectManager.kt
+++ b/app/src/main/java/com/uc/caffeine/data/HealthConnectManager.kt
@@ -3,12 +3,15 @@ package com.uc.caffeine.data
 import android.content.Context
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.HydrationRecord
 import androidx.health.connect.client.records.NutritionRecord
+import androidx.health.connect.client.records.Record
 import androidx.health.connect.client.records.SleepSessionRecord
 import androidx.health.connect.client.records.metadata.Metadata as HCMetadata
 import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.time.TimeRangeFilter
 import androidx.health.connect.client.units.Mass
+import androidx.health.connect.client.units.Volume
 import com.uc.caffeine.data.model.ConsumptionEntry
 import java.time.Duration
 import java.time.Instant
@@ -36,8 +39,9 @@ class HealthConnectManager(private val context: Context) {
     private val nutritionWrite = HealthPermission.getWritePermission(NutritionRecord::class)
     private val nutritionRead  = HealthPermission.getReadPermission(NutritionRecord::class)
     private val sleepRead      = HealthPermission.getReadPermission(SleepSessionRecord::class)
+    private val hydrationWrite = HealthPermission.getWritePermission(HydrationRecord::class)
 
-    val allPermissions = setOf(nutritionWrite, nutritionRead, sleepRead)
+    val allPermissions = setOf(nutritionWrite, nutritionRead, sleepRead, hydrationWrite)
     val sleepPermissions = setOf(sleepRead)
 
     fun isAvailable(): Boolean =
@@ -62,11 +66,15 @@ class HealthConnectManager(private val context: Context) {
     suspend fun hasSleepPermission(): Boolean =
         grantedPermissionsOrNull()?.contains(sleepRead) == true
 
+    suspend fun hasHydrationWritePermission(): Boolean =
+        grantedPermissionsOrNull()?.contains(hydrationWrite) == true
+
     /** True only when Health Connect answered and the sleep permission is definitively not granted. */
     suspend fun isSleepPermissionRevoked(): Boolean =
         grantedPermissionsOrNull()?.let { sleepRead !in it } == true
 
     private fun clientRecordId(entryId: Int): String = "caffeine_entry_$entryId"
+    private fun clientHydrationRecordId(entryId: Int): String = "caffeine_entry_${entryId}_hydration"
 
     private fun ConsumptionEntry.toNutritionRecord(zoneId: ZoneId): NutritionRecord {
         val start = Instant.ofEpochMilli(startedAtMillis)
@@ -86,14 +94,37 @@ class HealthConnectManager(private val context: Context) {
         )
     }
 
-    suspend fun writeEntry(entry: ConsumptionEntry, zoneId: ZoneId = ZoneId.systemDefault()) {
+    private fun ConsumptionEntry.toHydrationRecord(volumeMl: Double, zoneId: ZoneId): HydrationRecord {
+        val start = Instant.ofEpochMilli(startedAtMillis)
+        val end = start.plusSeconds(normalizedDurationMinutes * 60L)
+        val zoneRules = zoneId.rules
+        return HydrationRecord(
+            startTime = start,
+            endTime = end,
+            volume = Volume.liters(volumeMl / 1000.0),
+            startZoneOffset = zoneRules.getOffset(start),
+            endZoneOffset = zoneRules.getOffset(end),
+            metadata = HCMetadata.manualEntry(
+                clientRecordId = clientHydrationRecordId(id),
+                clientRecordVersion = System.currentTimeMillis(),
+            ),
+        )
+    }
+
+    suspend fun writeEntry(
+        entry: ConsumptionEntry,
+        zoneId: ZoneId = ZoneId.systemDefault(),
+        volumeMl: Double? = null,
+    ) {
         val c = client ?: return
         // Imported records are owned by another app — never echo them back
         if (entry.healthConnectRecordId != null) return
         if (!hasPermission()) return
-        runCatching {
-            c.insertRecords(listOf(entry.toNutritionRecord(zoneId)))
+        val records = mutableListOf<Record>(entry.toNutritionRecord(zoneId))
+        if (volumeMl != null && volumeMl > 0.0 && hasHydrationWritePermission()) {
+            records.add(entry.toHydrationRecord(volumeMl, zoneId))
         }
+        runCatching { c.insertRecords(records) }
     }
 
     suspend fun syncAll(entries: List<ConsumptionEntry>, zoneId: ZoneId = ZoneId.systemDefault()) {
@@ -128,6 +159,13 @@ class HealthConnectManager(private val context: Context) {
         val clientIds = entryIds.map { clientRecordId(it) }
         runCatching {
             c.deleteRecords(NutritionRecord::class, emptyList(), clientIds)
+        }
+        // Also delete corresponding hydration records
+        if (hasHydrationWritePermission()) {
+            val hydrationClientIds = entryIds.map { clientHydrationRecordId(it) }
+            runCatching {
+                c.deleteRecords(HydrationRecord::class, emptyList(), hydrationClientIds)
+            }
         }
     }
 

--- a/app/src/main/java/com/uc/caffeine/ui/viewmodel/CaffeineViewModel.kt
+++ b/app/src/main/java/com/uc/caffeine/ui/viewmodel/CaffeineViewModel.kt
@@ -576,7 +576,8 @@ class CaffeineViewModel(application: Application) : AndroidViewModel(application
             val settings = userSettings.value
             if (settings.healthConnectEnabled) {
                 val zoneId = settings.resolvedZoneId()
-                runCatching { healthConnectManager.writeEntry(entry.copy(id = newId.toInt()), zoneId) }
+                val volumeMl = defaultUnit.milliliters
+                runCatching { healthConnectManager.writeEntry(entry.copy(id = newId.toInt()), zoneId, volumeMl) }
             }
         }
     }
@@ -602,7 +603,8 @@ class CaffeineViewModel(application: Application) : AndroidViewModel(application
             val settings = userSettings.value
             if (settings.healthConnectEnabled) {
                 val zoneId = settings.resolvedZoneId()
-                runCatching { healthConnectManager.writeEntry(entry.copy(id = newId.toInt()), zoneId) }
+                val volumeMl = unit.milliliters?.let { it * quantity }
+                runCatching { healthConnectManager.writeEntry(entry.copy(id = newId.toInt()), zoneId, volumeMl) }
             }
         }
     }
@@ -703,7 +705,8 @@ class CaffeineViewModel(application: Application) : AndroidViewModel(application
                     durationMinutes = coercedDuration,
                 )
                 val zoneId = settings.resolvedZoneId()
-                runCatching { healthConnectManager.writeEntry(updatedEntry, zoneId) }
+                val volumeMl = unit.milliliters?.let { it * quantity }
+                runCatching { healthConnectManager.writeEntry(updatedEntry, zoneId, volumeMl) }
             }
         }
     }


### PR DESCRIPTION
# Add hydration data sync to Health Connect
When logging a drink (coffee, tea, etc.), the app already syncs the caffeine content to Health Connect as a NutritionRecord. This PR adds an HydrationRecord, so Health Connect also track the user's hydration.

## Changes
- AndroidManifest.xml — Declares the WRITE_HYDRATION permission required by Health Connect
- HealthConnectManager.kt — Adds HydrationRecord write capability alongside the existing NutritionRecord writes. A volumeMl parameter is passed through the call chain. When present and the hydration permission is granted, a HydrationRecord is inserted in the same batch as the NutritionRecord. Deletion also cascades to the associated hydration record. The hydration permission is bundled into the existing allPermissions set so it's requested together with the nutrition permission.
- CaffeineViewModel.kt — Computes the volume (quantity × unit.milliliters) at the three logging call sites that have access to the DrinkUnit data: logDrink(), logDrinkFromAddScreen(), and updateLoggedEntry(). Call sites without unit data (coach dose, recent drink, widget quick-log) pass null — no hydration record is created, which is the expected behavior.

## What it means for users
- The next time they enable Health Connect, a new "Hydration" permission will appear in the grant dialog
- From that point on, every logged drink with a known volume (e.g., 250ml coffee, 330ml can) creates both a caffeine record and a hydration record in Health Connect
- Past entries are not backfilled

## Disclaimer
I used AI assistance to help implement these changes. I am not an experienced Android/Kotlin developer, so please review carefully — especially the Health Connect API usage and permission flow.

## Screenshot
<img width="1024" height="658" alt="hydration_2" src="https://github.com/user-attachments/assets/1546fec4-4d15-4216-bb63-6b89a6aede8a" />
